### PR TITLE
feat: leave migration files in engine

### DIFF
--- a/lib/taro_core/engine.rb
+++ b/lib/taro_core/engine.rb
@@ -1,5 +1,17 @@
 module TaroCore
   class Engine < ::Rails::Engine
+    # :nocov:
+    initializer :append_migrations do |app|
+      # This prevents migrations from being loaded twice from the inside of the
+      # gem itself (dummy test app)
+      if app.root.to_s !~ /#{root}/
+        config.paths["db/migrate"].expanded.each do |migration_path|
+          app.config.paths["db/migrate"] << migration_path
+        end
+      end
+    end
+    # :nocov:
+
     config.generators do |g|
       g.test_framework :rspec
       g.template_engine :haml


### PR DESCRIPTION
### Resolves #

### Proposed Changes
- Leave migration files in engine

### Check list
- [x] I have ran `bundle exec rubocop`
- [x] I have ran `bundle exec rspec`
